### PR TITLE
Cursor Hover support

### DIFF
--- a/README.pod
+++ b/README.pod
@@ -119,7 +119,9 @@ Create a clickable area starting from the current position, when the area is cli
 
 Eg. I<%{A:reboot:} Click here to reboot %{A}>
 
-The I<button> field is optional, it defaults to the left button, and it's a number ranging from 1 to 5 which maps to the left, middle, right, scroll up and scroll down movements. Your mileage may vary.
+The I<button> field is optional, it defaults to the left button, and it's a number ranging from 0 to 5 which maps to the hover, left, middle, right, scroll up and scroll down movements. Your mileage may vary.
+
+NOTE: Using the hover option will make lemonbar generate output for every mouse movement over an area.
 
 Nested clickable areas can trigger different commands.
 

--- a/lemonbar.c
+++ b/lemonbar.c
@@ -630,7 +630,7 @@ parse (char *text)
                     case 'A':
                               button = XCB_BUTTON_INDEX_1;
                               // The range is 1-5
-                              if (isdigit(*p) && (*p > '0' && *p < '6'))
+                              if (isdigit(*p) && (*p >= '0' && *p < '6'))
                                   button = *p++ - '0';
                               if (!area_add(p, block_end, &p, cur_mon, pos_x, align, button))
                                   return;
@@ -916,7 +916,7 @@ monitor_new (int x, int y, int width, int height)
                       XCB_WINDOW_CLASS_INPUT_OUTPUT, visual,
                       XCB_CW_BACK_PIXEL | XCB_CW_BORDER_PIXEL | XCB_CW_OVERRIDE_REDIRECT | XCB_CW_EVENT_MASK | XCB_CW_COLORMAP,
     (const uint32_t []) {
-        bgc.v, bgc.v, dock, XCB_EVENT_MASK_EXPOSURE | XCB_EVENT_MASK_BUTTON_PRESS, colormap
+        bgc.v, bgc.v, dock, XCB_EVENT_MASK_EXPOSURE | XCB_EVENT_MASK_BUTTON_PRESS | XCB_EVENT_MASK_POINTER_MOTION, colormap
     });
 
     ret->pixmap = xcb_generate_id(c);
@@ -1402,6 +1402,7 @@ main (int argc, char **argv)
     xcb_generic_event_t *ev;
     xcb_expose_event_t *expose_ev;
     xcb_button_press_event_t *press_ev;
+    xcb_motion_notify_event_t *hover_ev;
     char input[4096] = {0, };
     bool permanent = false;
     int geom_v[4] = { -1, -1, 0, 0 };
@@ -1518,6 +1519,16 @@ main (int argc, char **argv)
                                 area_t *area = area_get(press_ev->event, press_ev->detail, press_ev->event_x);
                                 // Respond to the click
                                 if (area) {
+                                    write(STDOUT_FILENO, area->cmd, strlen(area->cmd));
+                                    write(STDOUT_FILENO, "\n", 1);
+                                }
+                            }
+                        break;
+                        case XCB_MOTION_NOTIFY:
+                            hover_ev = (xcb_motion_notify_event_t *)ev;
+                            {
+                                area_t *area = area_get(hover_ev->event, hover_ev->detail, hover_ev->event_x);
+                                if (area){
                                     write(STDOUT_FILENO, area->cmd, strlen(area->cmd));
                                     write(STDOUT_FILENO, "\n", 1);
                                 }


### PR DESCRIPTION
In addition to various mouse clicks, now one can make lemonbar generate output based on hovering over an area ( `%{A0}` ) (demo: https://gfycat.com/EvenObviousAmazontreeboa). Currently it makes lemonbar generates output for every hover movement and more complex scenarios can be implemented if required (such as mouseleave / mouseenter events).

I find this feature useful and was hoping not having to maintain a separate fork just for this small feature. :)