### PR TITLE
Fix multiline input

### DIFF
--- a/lemonbar.c
+++ b/lemonbar.c
@@ -8,6 +8,7 @@
 #include <ctype.h>
 #include <signal.h>
 #include <poll.h>
+#include <fcntl.h>
 #include <getopt.h>
 #include <unistd.h>
 #include <errno.h>
@@ -1533,6 +1534,10 @@ main (int argc, char **argv)
     free(instance_name);
     // Get the fd to Xserver
     pollin[1].fd = xcb_get_file_descriptor(c);
+
+    // Prevent fgets to block
+    fcntl(STDIN_FILENO, F_SETFL, O_NONBLOCK);
+	
     for (;;) {
         bool redraw = false;
 
@@ -1546,9 +1551,9 @@ main (int argc, char **argv)
                 else break;                         // ...bail out
             }
             if (pollin[0].revents & POLLIN) { // New input, process it
-                if (fgets(input, sizeof(input), stdin) == NULL)
-                    break; // EOF received
-
+                input[0] = '\0';
+                while (fgets(input, sizeof(input), stdin) != NULL)
+                    ; // Drain the buffer, the last line is actually used
                 parse(input);
                 redraw = true;
             }


### PR DESCRIPTION
Lemonbar has a bug, that it only reads the first line from input, if lines come fast, for example:
```sh
{echo a; echo b} | lemonbar -p
```
will show "a" and not "b". See
https://github.com/LemonBoy/bar/issues/107

This fix makes lemonbar read all lines from input and show the last one. It is taken from here:
https://github.com/LemonBoy/bar/pull/186/commits/309047f20541b831df389eb2e7a1c13130eab8b2